### PR TITLE
Add option to only change the text color without providing any border or background.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [unreleased] yyyy-mm-dd
+### Changed
+- Ability to disable background/border (only change text color)
+
 ## [1.0.0] 2021-02-01
 ### Changed
 - Extension name & links

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
 					"default": "background",
 					"enum": [
 						"background",
-						"border"
+						"border",
+						"textonly"
 					],
 					"description": "Controls the highlight styling."
 				},

--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -38,8 +38,11 @@ export class Decoration {
     if (stylingType === 'background') {
       Decoration.decorationOptions.backgroundColor = stylingColor;
       Decoration.decorationOptions.border = 'none';
-    } else {
+    } else if (stylingType === 'border') {
       Decoration.decorationOptions.border = `1px solid ${stylingColor} `;
+      Decoration.decorationOptions.backgroundColor = 'transparent';
+    } else {
+      Decoration.decorationOptions.border = 'none';
       Decoration.decorationOptions.backgroundColor = 'transparent';
     }
 


### PR DESCRIPTION
I would like to only change the text color, and not have any border or background. Would this do the trick? (I'm not sure how to test this out)

@zerefdev Apologies for the messed up PR in https://github.com/CleanCut/todo-highlighter/pull/1 -- That was an attempt to use the VS Code Pull Request plugin to create a pull request within VS Code. Not a great experience! 🙁  I think I'll stick with the web UI.